### PR TITLE
[DEP-6650] Add OCI-Factory update CI step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,43 @@ jobs:
       packages: write  # Needed to publish to GitHub Container Registry
       contents: write  # Needed to create GitHub release
 
+  oci-factory:
+    name: Update OCI-Factory
+    needs:
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Golang setup
+        uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.22.0"
+      - name: Install oci-factory
+        run: |
+          sudo apt update && sudo apt install -y git
+          go install github.com/canonical/oci-factory/tools/cli-client/cmd/oci-factory@latest
+          go install github.com/mikefarah/yq/v4@v4.44.3
+      - name: Set binary paths to environment
+        run: |
+          echo OCI_FACTORY=$(go env GOPATH)/bin/oci-factory >> $GITHUB_ENV
+          echo YQ=$(go env GOPATH)/bin/yq >> $GITHUB_ENV
+      - name: Set image version to environment
+        run: |
+          echo IMAGE_MYSQL_MAJOR_VERSION=$($YQ '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
+          echo IMAGE_MYSQL_MINOR_VERSION=$($YQ '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
+          echo IMAGE_OS_VERSION=$($YQ '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV
+      - name: Release
+        run: |
+          $OCI_FACTORY upload -y --release \
+            track=${IMAGE_MYSQL_MAJOR_VERSION}.${IMAGE_MYSQL_MINOR_VERSION}-${IMAGE_OS_VERSION},\
+            risks=edge
+        env:
+          GITHUB_TOKEN: ${{ secrets.token }}
+
   sbom:
     name: Generate Software Bill of Materials
     needs:
-      - build
       - release
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,13 +51,15 @@ jobs:
           echo YQ=$(go env GOPATH)/bin/yq >> $GITHUB_ENV
       - name: Set image version to environment
         run: |
-          echo IMAGE_MYSQL_MAJOR_VERSION=$($YQ '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
-          echo IMAGE_MYSQL_MINOR_VERSION=$($YQ '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
-          echo IMAGE_OS_VERSION=$($YQ '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV
+          echo END_OF_LIFE=$(date -d "$(date +'%Y-%m-%d') + 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
+          echo MYSQL_MAJOR_VERSION=$($YQ '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MINOR_VERSION=$($YQ '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
+          echo OS_VERSION=$($YQ '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV
       - name: Release
         run: |
           $OCI_FACTORY upload -y --release \
-            track=${IMAGE_MYSQL_MAJOR_VERSION}.${IMAGE_MYSQL_MINOR_VERSION}-${IMAGE_OS_VERSION},\
+            eol=${END_OF_LIFE},\
+            track=${MYSQL_MAJOR_VERSION}.${MYSQL_MINOR_VERSION}-${OS_VERSION},\
             risks=edge
         env:
           GITHUB_TOKEN: ${{ secrets.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           echo YQ=$(go env GOPATH)/bin/yq >> $GITHUB_ENV
       - name: Set image version to environment
         run: |
-          echo END_OF_LIFE=$(date -d "$(date +'%Y-%m-%d') + 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
+          echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
           echo MYSQL_MAJOR_VERSION=$($YQ '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
           echo MYSQL_MINOR_VERSION=$($YQ '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
           echo OS_VERSION=$($YQ '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,21 +40,21 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ">=1.22.0"
-      - name: Install oci-factory
+      - name: Install dependencies
         run: |
-          sudo apt update && sudo apt install -y git
+          sudo apt update
+          sudo apt install git
+          sudo apt install yq
           go install github.com/canonical/oci-factory/tools/cli-client/cmd/oci-factory@latest
-          go install github.com/mikefarah/yq/v4@v4.44.3
       - name: Set binary paths to environment
         run: |
           echo OCI_FACTORY=$(go env GOPATH)/bin/oci-factory >> $GITHUB_ENV
-          echo YQ=$(go env GOPATH)/bin/yq >> $GITHUB_ENV
       - name: Set image version to environment
         run: |
           echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
-          echo MYSQL_MAJOR_VERSION=$($YQ '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
-          echo MYSQL_MINOR_VERSION=$($YQ '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
-          echo OS_VERSION=$($YQ '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MAJOR_VERSION=$(yq '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MINOR_VERSION=$(yq '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
+          echo OS_VERSION=$(yq '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV
       - name: Release
         run: |
           $OCI_FACTORY upload -y --release \


### PR DESCRIPTION
This PR adds a new step to the `release.yaml` workflow in order to automatize the releases of the public MySQL rock (the one that goes into Dockerhub's Ubuntu namespace). The proposed step is based on the one Identity folks have in the public Hydra rock repository ([reference](https://github.com/canonical/hydra-rock/blob/a75226fa51162ea0ebbd56f2b30ca862d1ef12c1/.github/workflows/publish.yaml#L51-L78)).

### Additional notes
- ~I have not extracted the EOL out of the `rockcraft.yaml` file, as I do not know what it should be~.

---

Depends on the OCI-Factory integration [PR](https://github.com/canonical/oci-factory/pull/389).