### PR TITLE
[DEP-6650] Fix image building process

### DIFF
--- a/config/my.cnf
+++ b/config/my.cnf
@@ -20,10 +20,10 @@
 # http://dev.mysql.com/doc/mysql/en/server-system-variables.html
 
 [mysqld]
-pid-file        = /var/run/mysqld/mysqld.pid
-socket          = /var/run/mysqld/mysqld.sock
-datadir         = /var/lib/mysql
-secure-file-priv= NULL
+pid-file         = /var/run/mysqld/mysqld.pid
+socket           = /var/run/mysqld/mysqld.sock
+datadir          = /var/lib/mysql
+secure-file-priv = NULL
 
 # Custom config should go here
 !includedir /etc/mysql/conf.d/

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -16,7 +16,7 @@ environment:
 services:
     mysql:
         override: replace
-        command: sh -c "/usr/local/bin/entrypoint.sh"
+        command: sh -c "/usr/local/bin/entrypoint.sh mysqld"
         startup: enabled
         user: mysql
         group: mysql

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -70,7 +70,8 @@ parts:
         stage:
             - etc/mysql/
         organize:
-            config: etc/mysql/config
+            config/conf.d: /etc/mysql/conf.d
+            config/my.cnf: /etc/mysql/my.cnf
     rock-entrypoint:
         plugin: dump
         source: .

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -47,37 +47,6 @@ _is_sourced() {
 		&& [ "${FUNCNAME[1]}" = 'source' ]
 }
 
-# usage: docker_process_init_files [file [file [...]]]
-#    ie: docker_process_init_files /always-initdb.d/*
-# process initializer files, based on file extensions
-docker_process_init_files() {
-	# mysql here for backwards compatibility "${mysql[@]}"
-	mysql=( docker_process_sql )
-
-	echo
-	local f
-	for f; do
-		case "$f" in
-			*.sh)
-				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
-				# https://github.com/docker-library/postgres/pull/452
-				if [ -x "$f" ]; then
-					mysql_note "$0: running $f"
-					"$f"
-				else
-					mysql_note "$0: sourcing $f"
-					. "$f"
-				fi
-				;;
-			*.sql)    mysql_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mysql_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mysql_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mysql_warn "$0: ignoring $f" ;;
-		esac
-		echo
-	done
-}
-
 mysql_check_config() {
 	local toRun=( "$@" --verbose --help ) errors
 	if ! errors="$("${toRun[@]}" 2>&1 >/dev/null)"; then
@@ -309,9 +278,6 @@ _main() {
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env
 
-			# check dir permissions to reduce likelihood of half-initialized database
-			ls /docker-entrypoint-initdb.d/ > /dev/null
-
 			docker_init_database_dir "$@"
 
 			mysql_note "Starting temporary server"
@@ -319,7 +285,6 @@ _main() {
 			mysql_note "Temporary server started."
 
 			docker_setup_db
-			docker_process_init_files /docker-entrypoint-initdb.d/*
 
 			mysql_expire_root_user
 


### PR DESCRIPTION
This PR fixes a couple of mistakes introduced when migrating the image building process from Docker to the new rockcraft machinery: the missing `mysqld` command, and an incorrect dumping of [config](https://github.com/canonical/mysql-rock/tree/8.0-24.04/config) files into the image.

I also noticed that the original Dockerfile was creating an **empty** `/docker-entrypoint-initdb.d` folder, just in case some initialization scripts / SQL statements were required for the image. Given that the current build process does not contain any, I think we should prune the [entrypoint.sh](https://github.com/canonical/mysql-rock/blob/8.0-24.04/scripts/entrypoint.sh) logic that depends on it, in order to avoid confusion.