### PR TITLE
[DPE-7191] Add Trivyignore file

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# Golang CVE fixed in upstream PR
+# https://go-review.googlesource.com/c/go/+/578375
+CVE-2024-24788
+
+# Golang CVE fixed in upstream PR
+# https://go-review.googlesource.com/c/go/+/590296
+CVE-2024-24790
+
+# Golang CVE fixed in upstream PR
+# https://go-review.googlesource.com/c/go/+/611239
+CVE-2024-34156


### PR DESCRIPTION
This PR adds a `.trivyignore` file in order to unlock the automatic publishing of the built rock into the OCI factory repo. Previous attempts to publish the rock have failed due to the detection of false-positive vulnerabilities (see [CI run](https://github.com/canonical/oci-factory/actions/runs/16118774952/)). This is the approach recommended by Cris Cordeiro.