### PR TITLE
[MISC] Fix OCI Factory publishing track

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,9 +84,9 @@ jobs:
       - name: Set image version to environment
         run: |
           echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
-          echo MYSQL_MAJOR_VERSION=$(yq '.version | split(".").0 // ""' rockcraft.yaml) >> $GITHUB_ENV
-          echo MYSQL_MINOR_VERSION=$(yq '.version | split(".").1 // ""' rockcraft.yaml) >> $GITHUB_ENV
-          echo OS_VERSION=$(yq '.base | split("@").1' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MAJOR_VERSION=$(yq '.version | split(".")[0]' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MINOR_VERSION=$(yq '.version | split(".")[1]' rockcraft.yaml) >> $GITHUB_ENV
+          echo OS_VERSION=$(yq '.base | split("@")[1]' rockcraft.yaml) >> $GITHUB_ENV
       - name: Release
         run: |
           $OCI_FACTORY upload -y --release \


### PR DESCRIPTION
This PR fixes a `yq` syntax error when installing the package from Debian package registry instead of directly from [source](https://github.com/mikefarah/yq). The first one installs version 3.X, while the second install version 4.X.