### PR TITLE
[MISC] Fix OCI Factory publishing track (II)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,9 +84,9 @@ jobs:
       - name: Set image version to environment
         run: |
           echo END_OF_LIFE=$(date -d "+ 5 years" "+%Y-%m-%d") >> $GITHUB_ENV
-          echo MYSQL_MAJOR_VERSION=$(yq '.version | split(".")[0]' rockcraft.yaml) >> $GITHUB_ENV
-          echo MYSQL_MINOR_VERSION=$(yq '.version | split(".")[1]' rockcraft.yaml) >> $GITHUB_ENV
-          echo OS_VERSION=$(yq '.base | split("@")[1]' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MAJOR_VERSION=$(yq --raw-output '.version | split(".")[0]' rockcraft.yaml) >> $GITHUB_ENV
+          echo MYSQL_MINOR_VERSION=$(yq --raw-output '.version | split(".")[1]' rockcraft.yaml) >> $GITHUB_ENV
+          echo OS_VERSION=$(yq --raw-output '.base | split("@")[1]' rockcraft.yaml) >> $GITHUB_ENV
       - name: Release
         run: |
           $OCI_FACTORY upload -y --release \


### PR DESCRIPTION
This PR fixes a `yq` value error when using it without the `--raw-output` flag, as it wraps the output in double quotes (`"`).