### PR TITLE
misc: CVEs ignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,3 +9,7 @@ CVE-2024-24790
 # Golang CVE fixed in upstream PR
 # https://go-review.googlesource.com/c/go/+/611239
 CVE-2024-34156
+
+# Golang CVE. golang pulled from ubuntu archive
+CVE-2025-47907
+CVE-2025-47906


### PR DESCRIPTION
## Issue

oci-factory vulnerability scan reports golang CVEs:
https://github.com/canonical/oci-factory/actions/runs/17982280130/job/51151860892


## Solution

CVEs from packages in ubuntu archive (gosu/golang) can have CVE ignored due maintenance policy.
