### PR TITLE
[DPE-8608] update package index before installing

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -26,6 +26,8 @@ parts:
     apt:
       plugin: nil
       override-build: |
+        # base image has outdated apt sources. See:
+        # https://github.com/canonical/rockcraft/issues/1005
         apt update
         apt -y upgrade
         apt -y dist-upgrade

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -23,6 +23,13 @@ services:
         group: mysql
 
 parts:
+    apt:
+      plugin: nil
+      override-build: |
+        apt update
+        apt -y upgrade
+        apt -y dist-upgrade
+        craftctl default
     mysql:
         plugin: nil
         stage-packages:


### PR DESCRIPTION
Base image has outdated indexes preventing installation of newest, security fixes
