### PR TITLE
[MISC] 8.0 - Remove gosu dependency

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,15 +1,3 @@
-# Golang CVE fixed in upstream PR
-# https://go-review.googlesource.com/c/go/+/578375
-CVE-2024-24788
-
-# Golang CVE fixed in upstream PR
-# https://go-review.googlesource.com/c/go/+/590296
-CVE-2024-24790
-
-# Golang CVE fixed in upstream PR
-# https://go-review.googlesource.com/c/go/+/611239
-CVE-2024-34156
-
 # Golang CVE. golang pulled from ubuntu archive
 CVE-2025-47907
 CVE-2025-47906

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: mysql
 base: ubuntu@24.04
-version: '8.0.44'
+version: '8.0.45'
 summary: MySQL rock OCI
 description: |
     MySQL built from the official MySQL package from the MySQL repository.

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -26,7 +26,6 @@ parts:
     mysql:
         plugin: nil
         overlay-packages:
-            - gosu
             - tzdata
             - mysql-client-8.0
             - mysql-server-core-8.0
@@ -35,7 +34,6 @@ parts:
         overlay-script: |
             craftctl default
             mkdir -p $CRAFT_OVERLAY/licenses
-            mv $CRAFT_OVERLAY/usr/share/doc/gosu/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-gosu
             mv $CRAFT_OVERLAY/usr/share/doc/mysql-client-8.0/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-mysql-client-8.0
             mv $CRAFT_OVERLAY/usr/share/doc/mysql-server-core-8.0/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-mysql-server-core-8.0
             mv $CRAFT_OVERLAY/usr/share/doc/openssl/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-openssl
@@ -93,4 +91,3 @@ parts:
         organize:
             config/conf.d: /etc/mysql/conf.d
             config/my.cnf: /etc/mysql/my.cnf
-

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -268,12 +268,6 @@ _main() {
 		docker_setup_env "$@"
 		docker_create_db_directories
 
-		# If container is started as root user, restart as dedicated mysql user
-		if [ "$(id -u)" = "0" ]; then
-			mysql_note "Switching to dedicated user 'mysql'"
-			exec gosu mysql "$BASH_SOURCE" "$@"
-		fi
-
 		# there's no database, so it needs to be initialized
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env


### PR DESCRIPTION
This PR mimics PostgreSQL slim rock in removing the `gosu` dependency (see [PR](https://github.com/canonical/postgresql-rock/pull/48)). We never needed it to begin with.

We need to bump the rock version to match latest MySQL 8.0.X binaries.