### PR TITLE
[MISC] 8.4 - Remove gosu dependency

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,15 +1,3 @@
-# Golang CVE fixed in upstream PR
-# https://go-review.googlesource.com/c/go/+/578375
-CVE-2024-24788
-
-# Golang CVE fixed in upstream PR
-# https://go-review.googlesource.com/c/go/+/590296
-CVE-2024-24790
-
-# Golang CVE fixed in upstream PR
-# https://go-review.googlesource.com/c/go/+/611239
-CVE-2024-34156
-
 # Golang CVE. golang pulled from ubuntu archive
 CVE-2025-47907
 CVE-2025-47906

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -30,7 +30,6 @@ parts:
     mysql:
         plugin: nil
         overlay-packages:
-            - gosu
             - tzdata
             - mysql-client=8.4.8-0ubuntu0.24.04.1~ppa1
             - mysql-server-core=8.4.8-0ubuntu0.24.04.1~ppa1
@@ -38,7 +37,6 @@ parts:
         overlay-script: |
             craftctl default
             mkdir -p $CRAFT_OVERLAY/licenses
-            mv $CRAFT_OVERLAY/usr/share/doc/gosu/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-gosu
             mv $CRAFT_OVERLAY/usr/share/doc/mysql-client/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-mysql-client
             mv $CRAFT_OVERLAY/usr/share/doc/mysql-server-core/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-mysql-server-core
             mv $CRAFT_OVERLAY/usr/share/doc/openssl/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-openssl

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -268,12 +268,6 @@ _main() {
 		docker_setup_env "$@"
 		docker_create_db_directories
 
-		# If container is started as root user, restart as dedicated mysql user
-		if [ "$(id -u)" = "0" ]; then
-			mysql_note "Switching to dedicated user 'mysql'"
-			exec gosu mysql "$BASH_SOURCE" "$@"
-		fi
-
 		# there's no database, so it needs to be initialized
 		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
 			docker_verify_minimum_env


### PR DESCRIPTION
This PR mimics PostgreSQL slim rock in removing the `gosu` dependency (see [PR](https://github.com/canonical/postgresql-rock/pull/48)). We never needed it to begin with.

---

Depends on http://github.com/canonical/mysql-rock/pull/21.