### PR TITLE
[MISC] add missing (no)permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ concurrency:
 on:
   pull_request:
 
+permissions: {}
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build rock
     uses: canonical/data-platform-workflows/.github/workflows/build_rock.yaml@v39.1.0
+    permissions: {}
 
   release:
     name: Release rock
@@ -34,6 +35,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}
     steps:
       - name: Install Syft
         run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
@@ -65,6 +67,7 @@ jobs:
     needs:
       - release
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow configuration files by explicitly setting empty `permissions` for several jobs and workflows. This is a security best practice to ensure jobs do not have unnecessary permissions by default.

Workflow permissions hardening:

* Added `permissions: {}` to the top-level of `.github/workflows/ci.yaml` to restrict default permissions for all jobs in the CI workflow.
* Added `permissions: {}` to the `build`, `release`, and `publish` jobs in `.github/workflows/release.yaml` to restrict permissions for these jobs. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR19) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR38) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR70)