### PR TITLE
[MISC] 8.4 - Run service command outside sh -c

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,7 +21,7 @@ environment:
 services:
     mysql:
         override: replace
-        command: sh -c "/usr/local/bin/entrypoint.sh mysqld"
+        command: /usr/local/bin/entrypoint.sh mysqld
         startup: enabled
         user: mysql
         group: mysql


### PR DESCRIPTION
This PR improves the `mysql` service entrypoint command to remove the `sh -c` wrapper, allowing the passing of args.

---

Based on PR https://github.com/canonical/postgresql-rock/pull/80