### PR TITLE
[MISC] 8.0 - Add Renovate config (II)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     permissions:
+      actions: read    # Needed for GitHub API call to get workflow version
       packages: write  # Needed to publish to GitHub Container Registry
       contents: write  # Needed to create git tags
 


### PR DESCRIPTION
This PR fixes a missing permission on the `release-rock-edge` workflow.