### PR TITLE
[MISC] 8.4 - Update workflows branch name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ concurrency:
 on:
   push:
     branches:
-      - 8.4-24.04
+      - 8.4/edge
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ See [LICENSE][repo-license].
 
 [release-badge]: https://github.com/canonical/mysql-rock/actions/workflows/release.yaml/badge.svg
 [release-link]: https://github.com/canonical/mysql-rock/actions/workflows/release.yaml
-[repo-license]: https://github.com/canonical/mysql-rock/blob/8.4-24.04/LICENSE
+[repo-license]: https://github.com/canonical/mysql-rock/blob/8.4/edge/LICENSE
 [repo-rockcraft]: https://github.com/canonical/rockcraft


### PR DESCRIPTION
This PR updates the GHA workflows branch name after renaming the main branches to follow DPE practices:

- `8.0-24.04` -> `8.0/edge`.
- `8.4-24.04` -> `8.4/edge`.