### PR TITLE
[MISC] 8.4 - Update workflows branch name (II)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ concurrency:
 on:
   push:
     branches:
-      - 8.4-24.04
+      - 8.4/edge
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ See [LICENSE][repo-license].
 
 [release-badge]: https://github.com/canonical/mysql-rock/actions/workflows/release.yaml/badge.svg
 [release-link]: https://github.com/canonical/mysql-rock/actions/workflows/release.yaml
-[repo-license]: https://github.com/canonical/mysql-rock/blob/8.4-24.04/LICENSE
+[repo-license]: https://github.com/canonical/mysql-rock/blob/8.4/edge/LICENSE
 [repo-rockcraft]: https://github.com/canonical/rockcraft


### PR DESCRIPTION
Previously merged [PR](https://github.com/canonical/mysql-rock/pull/34) targeted the wrong branch (`8.4-24.04`). Having an unusual default branch is error prone 🤦🏻‍♂️ 