### PR TITLE
[MISC] (8.4/edge) Modernize Rock testing, take 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,15 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           go install github.com/canonical/spread/cmd/spread@latest
-          sudo snap install lxd
-          sudo adduser "$USER" lxd
-          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
-          sudo --user "$USER" --preserve-env=PATH -- env -- lxd waitready
-          sudo --user "$USER" --preserve-env=PATH -- env -- lxd init --auto
-          # Workaround for Docker & LXD on same machine
-          sudo iptables -F FORWARD
-          sudo iptables -P FORWARD ACCEPT
       - name: Run tests
         run: |
           ROCK_FILENAME=$(ls -- *.rock)
-          sudo --user "$USER" --preserve-env=CRAFT_ARTIFACT -- env -- CRAFT_ARTIFACT="$(pwd)/$ROCK_FILENAME" "$HOME/go/bin/spread" -v
+          CRAFT_ARTIFACT="$(pwd)/$ROCK_FILENAME" "$HOME/go/bin/spread" -v github-ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,17 +48,18 @@ jobs:
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*-${{ matrix.platform.arch }}
           merge-multiple: true
-      - name: Run tests
+      - name: Install dependencies
         run: |
-          # lxd is necessary for spread
+          go install github.com/canonical/spread/cmd/spread@latest
           sudo snap install lxd
           sudo adduser "$USER" lxd
           # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd waitready
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd init --auto
+          sudo --user "$USER" --preserve-env=PATH -- env -- lxd waitready
+          sudo --user "$USER" --preserve-env=PATH -- env -- lxd init --auto
           # Workaround for Docker & LXD on same machine
           sudo iptables -F FORWARD
           sudo iptables -P FORWARD ACCEPT
-
-          sudo snap install rockcraft --classic --edge
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- rockcraft test
+      - name: Run tests
+        run: |
+          ROCK_FILENAME=$(ls -- *.rock)
+          sudo --user "$USER" --preserve-env=CRAFT_ARTIFACT -- env -- CRAFT_ARTIFACT="$(pwd)/$ROCK_FILENAME" "$HOME/go/bin/spread" -v

--- a/spread.yaml
+++ b/spread.yaml
@@ -13,6 +13,17 @@ backends:
     systems:
       - ubuntu-24.04
 
+  github-ci:
+    type: adhoc
+    manual: true
+    allocate: ADDRESS $(./spread/.extension allocate ci)
+    discard: ./spread/.extension discard ci
+    environment:
+      CI: '$(HOST: echo $CI)'
+    systems:
+      - ubuntu-24.04:
+          username: runner
+
 suites:
   spread/tests/:
     summary: General integration tests

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,8 +1,15 @@
 project: mysql-rock
 
+path: /home/ubuntu/mysql-rock
+
+environment:
+  CRAFT_ARTIFACT: $(HOST:printenv CRAFT_ARTIFACT)
+
 backends:
-  craft:
-    type: craft
+  lxd-vm:
+    type: adhoc
+    allocate: ADDRESS $(./spread/.extension allocate lxd-vm)
+    discard: ./spread/.extension discard lxd-vm
     systems:
       - ubuntu-24.04
 
@@ -11,20 +18,11 @@ suites:
     summary: General integration tests
 
     prepare: |
-      # For 'rockcraft.skopeo'
-      snap install rockcraft --classic --edge
-      snap install docker
-
-      # Wait for docker daemon to come online
-      apt install -y retry
-      retry --times=10 --delay 2 -- docker run hello-world
-
-      # Load the rock into docker
-      rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:mysql:spreadtest
-
-      # Install mysql client
       apt update
-      apt install -y mysql-client
+      apt install -y retry mysql-client skopeo
+      snap install docker
+      retry --times=10 --delay=2 -- docker run hello-world
+      skopeo --insecure-policy copy "oci-archive:${SPREAD_PATH}/$(basename "${CRAFT_ARTIFACT}")" docker-daemon:mysql:spreadtest
     prepare-each: |
       docker run -d --rm -e MYSQL_ROOT_PASSWORD=myS3cr3tp@ss -p 3432:3306 --name "${SPREAD_TASK//\//_}" mysql:spreadtest
       # wait for initialization
@@ -32,7 +30,7 @@ suites:
     restore-each: |
       docker kill "${SPREAD_TASK//\//_}" || true
     restore: |
-      docker image rm --force mysql:spreadtest
+      docker image rm --force mysql:spreadtest || true
 
 exclude:
   - .git

--- a/spread/.extension
+++ b/spread/.extension
@@ -95,8 +95,21 @@ allocate_lxdvm() {
 }
 
 discard_lxdvm() {
-    instance_name="$(lxc ls -f csv | grep ",$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
-    lxc delete -f "$instance_name"
+    instance_name="$(lxc ls -f json |
+  jq -r --arg addr "$SPREAD_SYSTEM_ADDRESS" '
+    .[] |
+    select(.type == "virtual-machine") |
+    .name as $name |
+    .state.network |
+    to_entries[] |
+    select(.key != "docker0" and .key != "lo") |
+    .value.addresses[] |
+    select(.family == "inet" and .scope == "global" and .address == $addr) |
+    $name
+  ' | head -1)"
+    if [ -n "$instance_name" ]; then
+        lxc delete -f "$instance_name" || true
+    fi
 }
 
 allocate_ci() {

--- a/spread/.extension
+++ b/spread/.extension
@@ -104,14 +104,15 @@ allocate_ci() {
         echo "This backend is intended to be used only in CI systems."
         exit 1
     fi
-    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
-    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
-    sudo systemctl daemon-reload
-    sudo systemctl restart ssh
+    sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
+PasswordAuthentication yes
+PermitEmptyPasswords yes
+EOF
 
-    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+    sudo passwd --delete "$USER"
 
-    # Print the instance address to stdout
+    sudo systemctl reload ssh || sudo systemctl restart ssh
+
     echo localhost >&3
 }
 

--- a/spread/.extension
+++ b/spread/.extension
@@ -118,8 +118,8 @@ allocate_ci() {
         exit 1
     fi
     sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
-PasswordAuthentication yes
-PermitEmptyPasswords yes
+    PasswordAuthentication yes
+    PermitEmptyPasswords yes
 EOF
 
     sudo passwd --delete "$USER"

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -21,4 +21,3 @@ execute: |
 
   docker exec -t "${SPREAD_TASK//\//_}" pebble logs
   docker exec -t "${SPREAD_TASK//\//_}" pebble services
-

--- a/spread/tests/versions/task.yaml
+++ b/spread/tests/versions/task.yaml
@@ -9,4 +9,3 @@ execute: |
         --port=3432 \
         --user=root \
         --execute="select @@version;" | grep -q -e "^${ROCK_VERSION}"
-


### PR DESCRIPTION
Similar in spirit to https://github.com/canonical/mysql-snap/pull/35.

This one is a bit more complicated because, as there's no official LXD VM backend in spread (https://github.com/canonical/spread/pull/185, https://github.com/canonical/spread/pull/286) and the QEMU one seems to be not very healthy (https://github.com/canonical/spread/issues/140, https://github.com/canonical/spread/issues/171), we have to jump through a few hoops to actually allocate LXD VMs from spread, which is needed to test our rock. #40 tried to use Podman inside LXD containers, without success.

This PR achieves separation between `rockcraft pack` and `spread`, meaning: you can run the tests without packing the artifact (or even try more [novel approaches](https://github.com/canonical/spread-plus)).

To achieve that, I needed to:
- Define a custom adhoc backend that reuses the `.extension` code (which is a [craft-application](https://github.com/canonical/craft-application/blob/main/craft_application/services/testing.py#L261-L274) construct)
- Add a `CRAFT_ARTIFACT` mandatory env variable to pass the path to the rock to test
- Add a `github-ci` backend, inspired by https://github.com/canonical/mysql-operators/blob/d454c6c8d199c60aa3a9e65cfedb26ebee35c1a5/machines/spread.yaml, that runs all the test operations directly on the host (kind of like "destructive mode"), to avoid having to allocate a LXD VM
- (Bonus) Fix LXD VM instance cleanup, the logic was broken and would leave the instance running

Notice that `spread/.extension` is not strictly needed anymore, but those scripts and instructions need to live somewhere anyway, I wanted to minimize the diff in this already sensitive PR.