### PR TITLE
[DPE-10580] Pack MySQL 9.7 as a rock from the snap

### DIFF
--- a/config/my.cnf
+++ b/config/my.cnf
@@ -24,14 +24,14 @@
 # see https://dev.mysql.com/doc/refman/9.7/en/connecting.html
 # TODO: Revert when non-snap artifact is used to build the rock
 [client]
-socket           = /var/run/mysqld/mysqld.sock
+socket              = /var/run/mysqld/mysqld.sock
 
 [mysqld]
 # Override the snap-compiled socket and mysqlx paths
-pid-file         = /var/run/mysqld/mysqld.pid
-socket           = /var/run/mysqld/mysqld.sock
-datadir          = /var/lib/mysql
-host_cache_size  = 0
-secure-file-priv = NULL
-mysqlx-socket    = /var/run/mysqld/mysqlx.sock
+pid-file            = /var/run/mysqld/mysqld.pid
+socket              = /var/run/mysqld/mysqld.sock
+datadir             = /var/lib/mysql
+host_cache_size     = 0
+secure-file-priv    = NULL
+mysqlx-socket       = /var/run/mysqld/mysqlx.sock
 mysqlx-bind-address = *

--- a/config/my.cnf
+++ b/config/my.cnf
@@ -25,3 +25,5 @@ socket           = /var/run/mysqld/mysqld.sock
 datadir          = /var/lib/mysql
 host_cache_size  = 0
 secure-file-priv = NULL
+mysqlx-socket    = /var/run/mysqld/mysqlx.sock
+mysqlx-bind-address = *

--- a/config/my.cnf
+++ b/config/my.cnf
@@ -27,6 +27,7 @@
 socket           = /var/run/mysqld/mysqld.sock
 
 [mysqld]
+# Override the snap-compiled socket and mysqlx paths
 pid-file         = /var/run/mysqld/mysqld.pid
 socket           = /var/run/mysqld/mysqld.sock
 datadir          = /var/lib/mysql

--- a/config/my.cnf
+++ b/config/my.cnf
@@ -19,6 +19,13 @@
 # For explanations see
 # http://dev.mysql.com/doc/mysql/en/server-system-variables.html
 
+# Override the snap-compiled socket path so that "mysql -h localhost" works
+# (On Unix, localhost implies socket connection with the compiled-in default path)
+# see https://dev.mysql.com/doc/refman/9.7/en/connecting.html
+# TODO: Revert when non-snap artifact is used to build the rock
+[client]
+socket           = /var/run/mysqld/mysqld.sock
+
 [mysqld]
 pid-file         = /var/run/mysqld/mysqld.pid
 socket           = /var/run/mysqld/mysqld.sock

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -9,7 +9,7 @@ license: Apache-2.0
 platforms:
     amd64:
     arm64:
-    s390x:
+    #s390x:  # No s390x snap available yet, restore when it's available
 
 environment:
     TZ: UTC

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: mysql
 base: ubuntu@26.04
-version: '8.4.8'
+version: '9.7.1'
 summary: MySQL rock OCI
 description: |
     MySQL built from the official MySQL package from the MySQL repository.
@@ -25,18 +25,25 @@ services:
 parts:
     mysql:
         plugin: nil
+        stage-snaps:
+            - mysql/9.7/edge
         overlay-packages:
             - tzdata
-            - mysql-client=8.4.8-0ubuntu1
-            - mysql-server-core=8.4.8-0ubuntu1
             - openssl
         overlay-script: |
             craftctl default
             mkdir -p $CRAFT_OVERLAY/licenses
-            mv $CRAFT_OVERLAY/usr/share/doc/mysql-client/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-mysql-client
-            mv $CRAFT_OVERLAY/usr/share/doc/mysql-server-core/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-mysql-server-core
             mv $CRAFT_OVERLAY/usr/share/doc/openssl/copyright $CRAFT_OVERLAY/licenses/COPYRIGHT-openssl
-            rm -rf $CRAFT_OVERLAY/etc/mysql
+        override-prime: |
+            craftctl default
+            # Remove stale snap config files (they reference /var/snap paths)
+            rm -f $CRAFT_PRIME/etc/my.cnf
+            rm -f $CRAFT_PRIME/etc/mysqld.cnf
+            # Remove snap metadata
+            rm -rf $CRAFT_PRIME/meta.mysql
+            # Move MySQL LICENSE
+            mkdir -p $CRAFT_PRIME/licenses
+            find $CRAFT_PRIME/usr/share/ -name 'LICENSE' -path '*/mysql*' -exec mv {} $CRAFT_PRIME/licenses/COPYRIGHT-mysql \;
     non-root-user:
         plugin: nil
         after:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -41,9 +41,8 @@ parts:
             rm -f $CRAFT_PRIME/etc/mysqld.cnf
             # Remove snap metadata
             rm -rf $CRAFT_PRIME/meta.mysql
-            # Move MySQL LICENSE
-            mkdir -p $CRAFT_PRIME/licenses
-            find $CRAFT_PRIME/usr/share/ -name 'LICENSE' -path '*/mysql*' -exec mv {} $CRAFT_PRIME/licenses/COPYRIGHT-mysql \;
+            # Move MySQL Router LICENSE alongside other MySQL licenses
+            mv $CRAFT_PRIME/usr/LICENSE.router $CRAFT_PRIME/licenses/COPYRIGHT-mysql-router
     non-root-user:
         plugin: nil
         after:

--- a/spread.yaml
+++ b/spread.yaml
@@ -37,7 +37,7 @@ suites:
     prepare-each: |
       docker run -d --rm -e MYSQL_ROOT_PASSWORD=myS3cr3tp@ss -p 3432:3306 --name "${SPREAD_TASK//\//_}" mysql:spreadtest
       # wait for initialization
-      docker exec "${SPREAD_TASK//\//_}" bash -c 'until mysql -u root --password=myS3cr3tp@ss -h localhost -e "select now();"; do sleep 1; done'
+      retry --times=30 --delay=2 -- docker exec "${SPREAD_TASK//\//_}" mysql -u root --password=myS3cr3tp@ss -h localhost -e "select now();"
     restore-each: |
       docker kill "${SPREAD_TASK//\//_}" || true
     restore: |

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -14,9 +14,11 @@ execute: |
   mysql --host 127.0.0.1 --password=myS3cr3tp@ss --port=3432 --user=root --execute="select now();" && exit 1 || true # failure expected
 
   docker exec -t "${SPREAD_TASK//\//_}" pebble start mysql
+  sleep 1
   mysql --host 127.0.0.1 --password=myS3cr3tp@ss --port=3432 --user=root --execute="select now();"
 
   docker exec -t "${SPREAD_TASK//\//_}" pebble restart mysql
+  sleep 1
   mysql --host 127.0.0.1 --password=myS3cr3tp@ss --port=3432 --user=root --execute="select now();"
 
   docker exec -t "${SPREAD_TASK//\//_}" pebble logs


### PR DESCRIPTION
Builds on https://github.com/canonical/mysql-snap/pull/34 and https://github.com/canonical/mysql-rock/pull/41.

Some adjustments were needed because we're building from the snap and not the Debian package.